### PR TITLE
Depend on crates.io published version, update README, bump version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_mixer"
 description = "SDL2_mixer bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_mixer"
-version = "0.0.3"
+version = "0.0.31"
 license = "MIT"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
 keywords = ["SDL", "windowing", "graphics", "music", "sound"]
@@ -13,12 +13,14 @@ path = "src/sdl2_mixer/lib.rs"
 
 [dependencies]
 bitflags = "0.1"
+sdl2 = "0.0.31"
+sdl2-sys = "0.0.31"
 
-[dependencies.sdl2]
-git = "https://github.com/AngryLawyer/rust-sdl2"
+# [dependencies.sdl2]
+# git = "https://github.com/AngryLawyer/rust-sdl2"
 
-[dependencies.sdl2-sys]
-git = "https://github.com/AngryLawyer/rust-sdl2"
+# [dependencies.sdl2-sys]
+# git = "https://github.com/AngryLawyer/rust-sdl2"
 
 [[bin]]
 name = "demo"

--- a/README.md
+++ b/README.md
@@ -1,45 +1,67 @@
-# Rust-SDL2_mixer
-
+Rust-SDL2_mixer
+=============
 
 [![Build Status](https://travis-ci.org/andelf/rust-sdl2_mixer.svg?branch=master)](https://travis-ci.org/andelf/rust-sdl2_mixer)
 
 Rust bindings for SDL2_mixer.
 
+## Overview
+
+Rust-SDL2_mixer is a library for talking to the new SDL2_mixer library from Rust.
+
+Rust-SDL2_mixer uses the MIT licence.
+
+## Requirements
+
+* [Rust-SDL2](https://github.com/AngryLawyer/rust-sdl2)
+* SDL2_mixer development libraries
+* Rust master or nightly
+
 ## Installation
 
-Requirements
+Place the following into your project's Cargo.toml file:
 
-* [Rust-sdl2](https://github.com/AngryLawyer/rust-sdl2)
-* sdl_mixer 2.0 development libraries
-* Rust nightly
-* Cargo nightly
-
-
-### normal
-
+```toml
+[dependencies]
+sdl2_mixer = "0.0.31" # Doesn't work yet, needs to be published.
 ```
+
+Or, to depend on the newest rust-sdl2_mixer, reference the repository:
+
+```toml
+[dependencies.sdl2_mixer]
+git = "https://github.com/andelf/rust-sdl2-mixer"
+```
+
+You can also just clone and build the library yourself:
+
+```bash
 git clone https://github.com/andelf/rust-sdl2_mixer
+cd rust-sdl2_mixer
 cargo build
 # TODO: OR if you are using the mac framework version
 rustc --cfg mac_framework src/sdl2_mixer/lib.rs
 ```
 
-### cargo
+If you're not using Cargo, you can compile the library manually:
 
-```
-[dependencies]
-sdl2_mixer = "$version-here$"
-```
-
-or
-
-```
-[dependencies.sdl2_mixer]
-git = "https://github.com/andelf/rust-sdl2_mixer"
+```bash
+git clone https://github.com/andelf/rust-sdl2_mixer
+cd rust-sdl2_mixer
+rustc src/sdl2_mixer/lib.rs
 ```
 
 ## Demo
 
+A simple demo that plays out a portion of a given music file is included:
+
+```bash
+cargo run path/to/music.(mp3|flac|ogg|wav)
 ```
-cargo run /path/to/wav_file.wav
+
+Or:
+
+```bash
+rustc -L. src/demo/main.rs -o demo
+./demo path/to/music.(mp3|flac|ogg|wav)
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or, to depend on the newest rust-sdl2_mixer, reference the repository:
 
 ```toml
 [dependencies.sdl2_mixer]
-git = "https://github.com/andelf/rust-sdl2-mixer"
+git = "https://github.com/andelf/rust-sdl2_mixer"
 ```
 
 You can also just clone and build the library yourself:


### PR DESCRIPTION
I ditched the github dependencies: the library now works with the newest version of rust-sdl2 (0.0.31) published on crates.io. I also bumped the rust-sdl2_mixer version from 0.0.3 to 0.0.31. The README was also updated, although one of the instructions is noted as faulty since this newest version isn't published yet.