### PR TITLE
Changed SDL_mixer to work with the newest version of SDL2 rust bindings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_mixer"
 description = "SDL2_mixer bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_mixer"
-version = "0.2.1"
+version = "0.3.0"
 license = "MIT"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
 keywords = ["SDL", "windowing", "graphics", "music", "sound"]
@@ -13,8 +13,8 @@ path = "src/sdl2_mixer/lib.rs"
 
 [dependencies]
 bitflags = "0.1"
-sdl2 = "0.2.1"
-sdl2-sys = "0.2.1"
+sdl2 = "0.3.0"
+sdl2-sys = "0.3.0"
 libc = "0.1.6"
 
 # [dependencies.sdl2]

--- a/src/demo/main.rs
+++ b/src/demo/main.rs
@@ -5,7 +5,7 @@ extern crate sdl2_mixer;
 
 use std::env;
 use std::path::Path;
-use sdl2::{INIT_AUDIO, INIT_TIMER};
+use sdl2::*;
 use sdl2_mixer::{INIT_MP3, INIT_FLAC, INIT_MOD, INIT_FLUIDSYNTH, INIT_MODPLUG,
                  INIT_OGG, DEFAULT_FREQUENCY};
 
@@ -24,7 +24,7 @@ fn demo(filename: &Path) {
 
     println!("linked version: {}", sdl2_mixer::get_linked_version());
 
-    let _ = sdl2::init(INIT_AUDIO | INIT_TIMER);
+    let _ = sdl2::init().audio().timer();
 
     println!("mixer initialized: {}", sdl2_mixer::init(
         INIT_MP3 | INIT_FLAC | INIT_MOD | INIT_FLUIDSYNTH |


### PR DESCRIPTION
I was having trouble using both the newest version of SDL2 and the SDL_mixer because it was pulling in 2 different versions of SDL and having a conflict.  This change allows SDL_mixer to work with the newest version of Rust-SDL2 bindings.