### PR TITLE
add: upgrade to SDL2 version 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_mixer"
 description = "SDL2_mixer bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_mixer"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
 keywords = ["SDL", "windowing", "graphics", "music", "sound"]
@@ -13,8 +13,8 @@ path = "src/sdl2_mixer/lib.rs"
 
 [dependencies]
 bitflags = "0.1"
-sdl2 = "0.3.0"
-sdl2-sys = "0.3.0"
+sdl2 = "0.4"
+sdl2-sys = "0.4"
 libc = "0.1.6"
 
 # [dependencies.sdl2]

--- a/src/sdl2_mixer/lib.rs
+++ b/src/sdl2_mixer/lib.rs
@@ -219,7 +219,7 @@ pub trait LoaderRWops {
     fn load_wav(&self) -> SdlResult<Chunk>;
 }
 
-impl LoaderRWops for RWops {
+impl<'a> LoaderRWops for RWops<'a> {
     /// Load src for use as a sample.
     fn load_wav(&self) -> SdlResult<Chunk> {
         let raw = unsafe {


### PR DESCRIPTION
Upgrade to the newest version of SDL2. The version of SDL2_mixer has been bumped to reflect this change, and to keep the version the same as the main SDL2 library.