### PR TITLE
Add a constructor for Channel.

### DIFF
--- a/src/sdl2_mixer/lib.rs
+++ b/src/sdl2_mixer/lib.rs
@@ -249,6 +249,11 @@ pub enum Fading {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Channel(isize);
 
+/// Return a channel object.
+pub fn channel(chan: isize) -> Channel {
+    Channel(chan)
+}
+
 /// Set the number of channels being mixed.
 pub fn allocate_channels(numchans: isize) -> isize {
     unsafe {


### PR DESCRIPTION
I couldn't figure out a way to do this otherwise?

``` rust
sdl2_mixer::init(
    INIT_MP3 | INIT_FLAC | INIT_MOD | INIT_FLUIDSYNTH |
    INIT_MODPLUG | INIT_OGG).bits();

// TODO: 0x8010 is SDL_audio flag
let _ = sdl2_mixer::open_audio(DEFAULT_FREQUENCY, 0x8010u16, 2, 1024);
sdl2_mixer::allocate_channels(8);

let sound = sdl2_mixer::Chunk::from_file(Path::new("somefile.wav")).unwrap();
let chan = sdl2_mixer::channel(1);
chan.set_volume(sdl2_mixer::MAX_VOLUME);
chan.play(&sound, 0);
```

Other considered options:

* `Channel::new(1)` (too long)
* `Channel(1)` (unnecessary dependency on data structure)