### PR TITLE
Updated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_mixer"
 description = "SDL2_mixer bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_mixer"
-version = "0.9.0"
+version = "0.10.0"
 license = "MIT"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
 keywords = ["SDL", "windowing", "graphics", "music", "sound"]
@@ -13,7 +13,7 @@ path = "src/sdl2_mixer/lib.rs"
 
 [dependencies]
 bitflags = "0.3.2"
-sdl2 = "0.11"
+sdl2 = "0.12"
 sdl2-sys = "0.7"
 libc = "0.2"
 

--- a/src/sdl2_mixer/lib.rs
+++ b/src/sdl2_mixer/lib.rs
@@ -171,7 +171,7 @@ pub fn get_chunk_decoder(index: isize) -> String {
 }
 
 /// The internal format for an audio chunk.
-#[derive(PartialEq)] #[allow(raw_pointer_derive)]
+#[derive(PartialEq)]
 pub struct Chunk {
     pub raw: *const ffi::Mix_Chunk,
     pub owned: bool
@@ -606,7 +606,7 @@ extern "C" fn c_music_finished_hook() {
 }
 
 /// This is an opaque data type used for Music data.
-#[derive(PartialEq)] #[allow(raw_pointer_derive)]
+#[derive(PartialEq)]
 pub struct Music {
     pub raw: *const ffi::Mix_Music,
     pub owned: bool,


### PR DESCRIPTION
- Bumped to 0.10.0
- Removed `allow(raw_pointer_derive)`, see discussion
https://github.com/rust-lang/rust/issues/14615