### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sdl2_mixer"
 description = "SDL2_mixer bindings for Rust"
 repository = "https://github.com/andelf/rust-sdl2_mixer"
-version = "0.12.0"
+version = "0.13.0"
 license = "MIT"
 authors = ["ShuYu Wang <andelf@gmail.com>"]
 keywords = ["SDL", "windowing", "graphics", "music", "sound"]
@@ -13,7 +13,7 @@ path = "src/sdl2_mixer/lib.rs"
 
 [dependencies]
 bitflags = "0.3.2"
-sdl2 = "0.13"
+sdl2 = "0.14"
 sdl2-sys = "0.8"
 libc = "0.2"
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -3,7 +3,6 @@ extern crate sdl2_mixer;
 
 use std::env;
 use std::path::Path;
-use sdl2::*;
 use sdl2_mixer::{INIT_MP3, INIT_FLAC, INIT_MOD, INIT_FLUIDSYNTH, INIT_MODPLUG, INIT_OGG,
                  AUDIO_S16LSB};
 


### PR DESCRIPTION
- Bumped to 0.13.0
- Removed unused `use` in demo example